### PR TITLE
include every day in the time series range; format numbers

### DIFF
--- a/server.js
+++ b/server.js
@@ -349,7 +349,6 @@ app.get('/api/home/:range',
             for(var d = startDate; moment(endDate).diff(moment(d), 'days') > 0; d = moment(d).add(1, 'days').format('YYYY-MM-DD')) {
               //console.log(d);
               if(ts[d]) {
-                console.log('matched at ' + d);
                 timeseries.push({t:d, v: ts[d]});
                 tmpNet = ts[d];
               } else {


### PR DESCRIPTION
include every day in the time series range, even if there's no data for the day. format numbers with commas for better usability.